### PR TITLE
feat: add configurable scraping pipeline and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,50 @@ data/
   manifest.json
 ```
 
+## 自定义站点采集与处理管道
+
+项目新增了一个可配置的采集管道，帮助你针对任意图片站点完成「抓取 → 本地落盘 → CSV 输出 → 本地 AI 识别 → （可选）腾讯云 COS 上传」的全流程处理。
+
+### 1. 准备配置
+
+复制示例配置并根据目标站点修改选择器、分页等信息：
+
+```bash
+cp pipeline.config.example.json pipeline.config.json
+```
+
+关键字段说明：
+
+- `targets`: 站点列表，使用 CSS 选择器声明如何从页面提取图片地址、标题、分类等信息；
+- `compression`: 本地压缩输出路径以及压缩参数；
+- `ai`: 是否启用本地 AI（使用 `@xenova/transformers` 模型，首次运行会自动下载权重）；
+- `cos`: 腾讯云 COS 上传开关与目标桶配置（需要 `TENCENT_SECRET_ID`/`TENCENT_SECRET_KEY` 环境变量）。
+
+### 2. 运行命令行流程
+
+```bash
+# 运行采集 + AI 识别 +（可选）COS 上传
+pnpm pipeline:run -- run
+
+# 只对指定站点执行
+pnpm pipeline:run -- run --targets 4kw,wallhaven
+
+# 仅重新上传未完成的文件
+pnpm pipeline:run -- upload
+```
+
+运行后会在 `data/pipeline` 下生成原图、压缩图以及 `metadata.csv` 文件，方便二次加工。
+
+### 3. 可视化界面
+
+使用内置的仪表盘管理任务：
+
+```bash
+pnpm pipeline:ui
+```
+
+浏览器打开 http://localhost:3000 即可手动触发采集、查看最新记录、确认上传状态。
+
 ## References
 - Playwright install & usage: https://playwright.dev/docs/intro
 - Sharp install & API: https://sharp.pixelplumbing.com/

--- a/package.json
+++ b/package.json
@@ -13,16 +13,30 @@
     "fetch:wallhaven": "bun --env-file=.env src/fetch_wallhaven.ts",
     "fetch:steamwe": "bun --env-file=.env src/fetch_steam_we.ts",
     "build:manifest": "bun --env-file=.env src/manifest/buildManifest.ts",
-    "pipeline:all": "npm run crawl:4kw && npm run fetch:pinterest && npm run fetch:steam:we && npm run build:manifest",
+    "pipeline:all": "npm run crawl:4kw && npm run fetch:pinterest && npm run fetch:steamwe && npm run build:manifest",
+    "pipeline:run": "bun --env-file=.env src/pipeline/run.ts",
+    "pipeline:ui": "bun --env-file=.env src/server/index.ts",
     "lint": "eslint . --ext .ts,.tsx || true"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.632.0",
+    "@xenova/transformers": "^2.17.2",
+    "cheerio": "^1.0.0",
+    "commander": "^12.1.0",
+    "cos-nodejs-sdk-v5": "^2.13.5",
+    "csv-parse": "^5.5.6",
+    "csv-stringify": "^6.5.2",
     "crypto-js": "^4.2.0",
+    "ejs": "^3.1.10",
+    "express": "^4.19.2",
+    "fs-extra": "^11.2.0",
     "dotenv": "^17.2.2",
     "image-hash": "^5.3.2",
     "node-fetch": "^3.3.2",
-    "sharp": "^0.33.4"
+    "p-limit": "^5.0.0",
+    "sharp": "^0.33.4",
+    "slugify": "^1.6.6",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.2",

--- a/pipeline.config.example.json
+++ b/pipeline.config.example.json
@@ -1,0 +1,50 @@
+{
+  "outputDir": "data/pipeline",
+  "csvPath": "data/pipeline/metadata.csv",
+  "compression": {
+    "outputDir": "data/pipeline/compressed",
+    "maxWidth": 1024,
+    "quality": 80
+  },
+  "ai": {
+    "enabled": true,
+    "classifierModel": "Xenova/vit-base-patch16-224",
+    "captionModel": "Xenova/blip-image-captioning-base",
+    "maxTags": 5
+  },
+  "cos": {
+    "enabled": false,
+    "bucket": "your-bucket",
+    "region": "ap-guangzhou",
+    "folder": "pipeline"
+  },
+  "targets": [
+    {
+      "name": "4K Wallpapers Demon Slayer",
+      "slug": "4kw",
+      "url": "https://4kwallpapers.com/demon-slayer-wallpapers/",
+      "baseUrl": "https://4kwallpapers.com/",
+      "itemSelector": ".box",
+      "image": {
+        "selector": "img",
+        "attr": "data-src"
+      },
+      "title": {
+        "selector": "h3 a"
+      },
+      "description": {
+        "selector": "p"
+      },
+      "tags": {
+        "selector": "h3 a",
+        "split": "-"
+      },
+      "pagination": {
+        "type": "pageParam",
+        "start": 1,
+        "end": 1,
+        "param": "page"
+      }
+    }
+  ]
+}

--- a/pipeline.config.json
+++ b/pipeline.config.json
@@ -1,0 +1,50 @@
+{
+  "outputDir": "data/pipeline",
+  "csvPath": "data/pipeline/metadata.csv",
+  "compression": {
+    "outputDir": "data/pipeline/compressed",
+    "maxWidth": 1024,
+    "quality": 80
+  },
+  "ai": {
+    "enabled": true,
+    "classifierModel": "Xenova/vit-base-patch16-224",
+    "captionModel": "Xenova/blip-image-captioning-base",
+    "maxTags": 5
+  },
+  "cos": {
+    "enabled": false,
+    "bucket": "your-bucket",
+    "region": "ap-guangzhou",
+    "folder": "pipeline"
+  },
+  "targets": [
+    {
+      "name": "4K Wallpapers Demon Slayer",
+      "slug": "4kw",
+      "url": "https://4kwallpapers.com/demon-slayer-wallpapers/",
+      "baseUrl": "https://4kwallpapers.com/",
+      "itemSelector": ".box",
+      "image": {
+        "selector": "img",
+        "attr": "data-src"
+      },
+      "title": {
+        "selector": "h3 a"
+      },
+      "description": {
+        "selector": "p"
+      },
+      "tags": {
+        "selector": "h3 a",
+        "split": "-"
+      },
+      "pagination": {
+        "type": "pageParam",
+        "start": 1,
+        "end": 1,
+        "param": "page"
+      }
+    }
+  ]
+}

--- a/src/pipeline/ai.ts
+++ b/src/pipeline/ai.ts
@@ -1,0 +1,143 @@
+import path from 'node:path';
+import sharp from 'sharp';
+import { DownloadedImage, AiAnalysis } from './types.js';
+import { ensureDir, fileNameWithExt, pathExists } from './utils.js';
+
+export interface AiAnalyzerOptions {
+  outputDir: string;
+  maxWidth: number;
+  quality: number;
+  classifierModel?: string;
+  captionModel?: string;
+  maxTags?: number;
+}
+
+interface TransformersModule {
+  pipeline: (task: string, model?: string) => Promise<any>;
+}
+
+async function loadTransformers(): Promise<TransformersModule | undefined> {
+  try {
+    const module = await import('@xenova/transformers');
+    return module as TransformersModule;
+  } catch (error) {
+    console.warn('[AI] Failed to load @xenova/transformers, skipping AI analysis.');
+    return undefined;
+  }
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const clamp = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
+  return `#${[clamp(r), clamp(g), clamp(b)]
+    .map((v) => v.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+async function computeDominantColors(imagePath: string): Promise<string[]> {
+  const stats = await sharp(imagePath).stats();
+  const dominantHex = rgbToHex(stats.dominant.r, stats.dominant.g, stats.dominant.b);
+  const average = await sharp(imagePath).resize(1, 1, { fit: 'inside' }).raw().toBuffer();
+  const averageHex = rgbToHex(
+    average[0] ?? stats.dominant.r,
+    average[1] ?? stats.dominant.g,
+    average[2] ?? stats.dominant.b,
+  );
+  return Array.from(new Set([dominantHex, averageHex]));
+}
+
+export class AiAnalyzer {
+  private readonly options: AiAnalyzerOptions;
+  private classifier?: any;
+  private captioner?: any;
+  private readonly maxTags: number;
+  private transformersModule?: TransformersModule;
+
+  constructor(options: AiAnalyzerOptions) {
+    this.options = options;
+    this.maxTags = options.maxTags ?? 5;
+  }
+
+  private async ensureTransformers(): Promise<boolean> {
+    if (this.transformersModule) return true;
+    const module = await loadTransformers();
+    if (!module) return false;
+    this.transformersModule = module;
+    return true;
+  }
+
+  private async getClassifier() {
+    if (!this.classifier) {
+      if (!(await this.ensureTransformers())) return undefined;
+      this.classifier = await this.transformersModule!.pipeline(
+        'image-classification',
+        this.options.classifierModel ?? 'Xenova/vit-base-patch16-224',
+      );
+    }
+    return this.classifier;
+  }
+
+  private async getCaptioner() {
+    if (!this.captioner) {
+      if (!(await this.ensureTransformers())) return undefined;
+      this.captioner = await this.transformersModule!.pipeline(
+        'image-to-text',
+        this.options.captionModel ?? 'Xenova/blip-image-captioning-base',
+      );
+    }
+    return this.captioner;
+  }
+
+  private async compressImage(image: DownloadedImage): Promise<string> {
+    const directory = path.join(this.options.outputDir, image.target.slug);
+    await ensureDir(directory);
+    const compressedFileName = fileNameWithExt(`${image.id}-compressed`, 'jpg');
+    const destination = path.join(directory, compressedFileName);
+    if (!(await pathExists(destination))) {
+      await sharp(image.localPath)
+        .resize({ width: this.options.maxWidth, withoutEnlargement: true })
+        .jpeg({ quality: this.options.quality })
+        .toFile(destination);
+    }
+    return destination;
+  }
+
+  async analyze(image: DownloadedImage): Promise<AiAnalysis> {
+    const compressedPath = await this.compressImage(image);
+    const colors = await computeDominantColors(compressedPath);
+
+    const analysis: AiAnalysis = {
+      compressedPath,
+      dominantColors: colors,
+    };
+
+    const classifier = await this.getClassifier();
+    if (classifier) {
+      try {
+        const predictions = await classifier(compressedPath, { topk: this.maxTags });
+        const labels = Array.isArray(predictions)
+          ? predictions.map((item: any) => item.label)
+          : [];
+        analysis.tags = labels.slice(0, this.maxTags);
+        analysis.categories = labels.slice(0, Math.min(3, labels.length));
+      } catch (error) {
+        console.warn('[AI] Failed to classify image', error);
+      }
+    }
+
+    const captioner = await this.getCaptioner();
+    if (captioner) {
+      try {
+        const generated = await captioner(compressedPath, { max_new_tokens: 50 });
+        if (Array.isArray(generated) && generated.length > 0) {
+          analysis.caption = generated[0].generated_text ?? generated[0].caption ?? undefined;
+        } else if (generated?.generated_text) {
+          analysis.caption = generated.generated_text;
+        }
+      } catch (error) {
+        console.warn('[AI] Failed to caption image', error);
+      }
+    }
+
+    return analysis;
+  }
+}

--- a/src/pipeline/config.ts
+++ b/src/pipeline/config.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { z } from 'zod';
+import { PipelineConfig } from './types.js';
+
+const fieldSelectorSchema = z.object({
+  selector: z.string(),
+  attr: z.string().optional(),
+  type: z.enum(['text', 'attr']).optional(),
+  split: z.string().optional(),
+  required: z.boolean().optional(),
+});
+
+const paginationSchema = z.object({
+  type: z.enum(['pageParam', 'increment']).default('pageParam'),
+  start: z.number().int().default(1),
+  end: z.number().int(),
+  param: z.string().optional(),
+  step: z.number().int().default(1),
+});
+
+const targetSchema = z.object({
+  name: z.string(),
+  slug: z.string().regex(/^[a-z0-9-]+$/i, 'slug must be alphanumeric with dashes'),
+  url: z.string().url(),
+  baseUrl: z.string().url().optional(),
+  itemSelector: z.string(),
+  image: z.object({
+    selector: z.string().optional(),
+    attr: z.string().optional(),
+    dataAttr: z.string().optional(),
+  }),
+  title: fieldSelectorSchema.optional(),
+  description: fieldSelectorSchema.optional(),
+  category: fieldSelectorSchema.or(z.string()).optional(),
+  tags: fieldSelectorSchema.optional(),
+  pagination: paginationSchema.optional(),
+  requestHeaders: z.record(z.string()).optional(),
+});
+
+const configSchema = z.object({
+  outputDir: z.string(),
+  csvPath: z.string(),
+  compression: z.object({
+    outputDir: z.string(),
+    maxWidth: z.number().positive(),
+    quality: z.number().min(1).max(100),
+  }),
+  ai: z.object({
+    enabled: z.boolean().default(false),
+    classifierModel: z.string().optional(),
+    captionModel: z.string().optional(),
+    maxTags: z.number().int().positive().default(5),
+  }).optional(),
+  cos: z.object({
+    enabled: z.boolean().default(false),
+    bucket: z.string(),
+    region: z.string(),
+    folder: z.string().optional(),
+    forcePathStyle: z.boolean().optional(),
+  }).optional(),
+  targets: z.array(targetSchema).min(1),
+});
+
+export async function loadConfig(configPath: string): Promise<PipelineConfig> {
+  const absolutePath = path.isAbsolute(configPath)
+    ? configPath
+    : path.join(process.cwd(), configPath);
+
+  const data = await fs.readFile(absolutePath, 'utf-8');
+  const parsed = configSchema.parse(JSON.parse(data));
+
+  return parsed;
+}
+
+export async function resolveConfigPath(relativePath: string): Promise<string> {
+  if (path.isAbsolute(relativePath)) {
+    return relativePath;
+  }
+  const cwd = process.cwd();
+  return path.join(cwd, relativePath);
+}
+
+export async function importConfigModule(configPath: string): Promise<PipelineConfig> {
+  const absolute = await resolveConfigPath(configPath);
+  const moduleUrl = pathToFileURL(absolute).href;
+  const mod = await import(moduleUrl);
+  const candidate = mod.default ?? mod.config ?? mod;
+  return configSchema.parse(candidate);
+}

--- a/src/pipeline/cos.ts
+++ b/src/pipeline/cos.ts
@@ -1,0 +1,75 @@
+import path from 'node:path';
+import COS from 'cos-nodejs-sdk-v5';
+import pLimit from 'p-limit';
+import { PipelineRecord } from './types.js';
+
+export interface CosUploadOptions {
+  bucket: string;
+  region: string;
+  folder?: string;
+  forcePathStyle?: boolean;
+  concurrency?: number;
+}
+
+function createCosClient(options: CosUploadOptions) {
+  const secretId = process.env.TENCENT_SECRET_ID;
+  const secretKey = process.env.TENCENT_SECRET_KEY;
+  if (!secretId || !secretKey) {
+    throw new Error('Missing TENCENT_SECRET_ID or TENCENT_SECRET_KEY environment variables.');
+  }
+  return new COS({
+    SecretId: secretId,
+    SecretKey: secretKey,
+    ForcePathStyle: options.forcePathStyle ?? false,
+  });
+}
+
+function resolveKey(record: PipelineRecord, folder?: string): string {
+  const fileName = path.basename(record.compressedPath ?? record.localPath);
+  if (!folder) return fileName;
+  return path.posix.join(folder.replace(/\\/g, '/'), fileName);
+}
+
+function buildCosUrl(bucket: string, region: string, key: string): string {
+  const normalizedKey = key.replace(/\\/g, '/');
+  return `https://${bucket}.cos.${region}.myqcloud.com/${normalizedKey}`;
+}
+
+export async function uploadToCos(records: PipelineRecord[], options: CosUploadOptions): Promise<PipelineRecord[]> {
+  const client = createCosClient(options);
+  const concurrency = options.concurrency ?? 3;
+  const limit = pLimit(concurrency);
+
+  const uploads = records.map((record) =>
+    limit(async () => {
+      if (record.remoteUrl) return record;
+      const filePath = record.compressedPath ?? record.localPath;
+      const key = resolveKey(record, options.folder);
+      await new Promise<void>((resolve, reject) => {
+        client.uploadFile({
+          Bucket: options.bucket,
+          Region: options.region,
+          Key: key,
+          FilePath: filePath,
+          SliceSize: 1024 * 1024,
+        }, (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+
+      const remoteUrl = buildCosUrl(options.bucket, options.region, key);
+      return {
+        ...record,
+        remoteUrl,
+        updatedAt: new Date().toISOString(),
+      } satisfies PipelineRecord;
+    }),
+  );
+
+  const updated = await Promise.all(uploads);
+  return updated;
+}

--- a/src/pipeline/csv.ts
+++ b/src/pipeline/csv.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import { PipelineRecord } from './types.js';
+import { decodeCsvArray, encodeCsvArray, ensureDir } from './utils.js';
+
+const columns = [
+  { key: 'id', header: 'id' },
+  { key: 'source', header: 'source' },
+  { key: 'pageUrl', header: 'pageUrl' },
+  { key: 'imageUrl', header: 'imageUrl' },
+  { key: 'localPath', header: 'localPath' },
+  { key: 'compressedPath', header: 'compressedPath' },
+  { key: 'remoteUrl', header: 'remoteUrl' },
+  { key: 'title', header: 'title' },
+  { key: 'description', header: 'description' },
+  { key: 'categories', header: 'categories' },
+  { key: 'tags', header: 'tags' },
+  { key: 'aiTags', header: 'aiTags' },
+  { key: 'aiCategories', header: 'aiCategories' },
+  { key: 'aiColors', header: 'aiColors' },
+  { key: 'aiCaption', header: 'aiCaption' },
+  { key: 'sha256', header: 'sha256' },
+  { key: 'bytes', header: 'bytes' },
+  { key: 'ext', header: 'ext' },
+  { key: 'updatedAt', header: 'updatedAt' },
+];
+
+export interface CsvRow {
+  id: string;
+  source: string;
+  pageUrl: string;
+  imageUrl: string;
+  localPath: string;
+  compressedPath?: string;
+  remoteUrl?: string;
+  title?: string;
+  description?: string;
+  categories?: string;
+  tags?: string;
+  aiTags?: string;
+  aiCategories?: string;
+  aiColors?: string;
+  aiCaption?: string;
+  sha256: string;
+  bytes: number;
+  ext: string;
+  updatedAt: string;
+}
+
+export async function loadCsv(filePath: string): Promise<PipelineRecord[]> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const records = parse(content, {
+      columns: true,
+      skip_empty_lines: true,
+    }) as CsvRow[];
+
+    return records.map((row) => ({
+      id: row.id,
+      target: {
+        name: row.source,
+        slug: row.source,
+        url: row.pageUrl,
+        itemSelector: '',
+        image: {},
+      },
+      pageUrl: row.pageUrl,
+      imageUrl: row.imageUrl,
+      fileName: path.basename(row.localPath),
+      localPath: row.localPath,
+      compressedPath: row.compressedPath,
+      remoteUrl: row.remoteUrl,
+      title: row.title,
+      description: row.description,
+      categories: decodeCsvArray(row.categories),
+      tags: decodeCsvArray(row.tags),
+      aiTags: decodeCsvArray(row.aiTags),
+      aiCategories: decodeCsvArray(row.aiCategories),
+      aiColors: decodeCsvArray(row.aiColors),
+      aiCaption: row.aiCaption,
+      sha256: row.sha256,
+      bytes: Number(row.bytes),
+      ext: row.ext,
+      updatedAt: row.updatedAt,
+    }));
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function saveCsv(filePath: string, records: PipelineRecord[]): Promise<void> {
+  const directory = path.dirname(filePath);
+  await ensureDir(directory);
+  const rows: CsvRow[] = records.map((record) => ({
+    id: record.id,
+    source: record.target.slug,
+    pageUrl: record.pageUrl,
+    imageUrl: record.imageUrl,
+    localPath: record.localPath,
+    compressedPath: record.compressedPath,
+    remoteUrl: record.remoteUrl,
+    title: record.title,
+    description: record.description,
+    categories: encodeCsvArray(record.categories),
+    tags: encodeCsvArray(record.tags),
+    aiTags: encodeCsvArray(record.aiTags),
+    aiCategories: encodeCsvArray(record.aiCategories),
+    aiColors: encodeCsvArray(record.aiColors),
+    aiCaption: record.aiCaption,
+    sha256: record.sha256,
+    bytes: record.bytes,
+    ext: record.ext,
+    updatedAt: record.updatedAt,
+  }));
+
+  const csv = stringify(rows, {
+    header: true,
+    columns,
+  });
+  await fs.writeFile(filePath, csv, 'utf-8');
+}

--- a/src/pipeline/download.ts
+++ b/src/pipeline/download.ts
@@ -1,0 +1,73 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import pLimit from 'p-limit';
+import { DownloadedImage, ScrapedImage } from './types.js';
+import { ensureDir, fileNameWithExt, guessExtensionFromUrl } from './utils.js';
+
+export interface DownloadOptions {
+  baseDir: string;
+  concurrency?: number;
+}
+
+async function downloadBuffer(url: string): Promise<Buffer> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'demon-slayer-pipeline/1.0 (+https://github.com/)',
+      Referer: url,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+export async function downloadImages(
+  items: ScrapedImage[],
+  options: DownloadOptions,
+): Promise<DownloadedImage[]> {
+  const concurrency = options.concurrency ?? 4;
+  const limit = pLimit(concurrency);
+  const downloads: Promise<DownloadedImage | undefined>[] = items.map((item) =>
+    limit(async () => {
+      const ext = guessExtensionFromUrl(item.imageUrl);
+      const directory = path.join(options.baseDir, item.target.slug, 'raw');
+      await ensureDir(directory);
+      const fileName = fileNameWithExt(item.id, ext);
+      const destination = path.join(directory, fileName);
+
+      try {
+        await fs.access(destination);
+        const buffer = await fs.readFile(destination);
+        const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
+        return {
+          ...item,
+          fileName,
+          localPath: destination,
+          sha256,
+          bytes: buffer.byteLength,
+          ext,
+        } satisfies DownloadedImage;
+      } catch {
+        // continue to download
+      }
+
+      const buffer = await downloadBuffer(item.imageUrl);
+      const sha256 = crypto.createHash('sha256').update(buffer).digest('hex');
+      await fs.writeFile(destination, buffer);
+      return {
+        ...item,
+        fileName,
+        localPath: destination,
+        sha256,
+        bytes: buffer.byteLength,
+        ext,
+      } satisfies DownloadedImage;
+    }),
+  );
+
+  const settled = await Promise.all(downloads);
+  return settled.filter((item): item is DownloadedImage => Boolean(item));
+}

--- a/src/pipeline/pipeline.ts
+++ b/src/pipeline/pipeline.ts
@@ -1,0 +1,108 @@
+import { AiAnalyzer } from './ai.js';
+import { loadCsv, saveCsv } from './csv.js';
+import { downloadImages } from './download.js';
+import { uploadToCos } from './cos.js';
+import { scrapeTarget } from './scrape.js';
+import {
+  PipelineConfig,
+  PipelineRecord,
+  PipelineRunOptions,
+} from './types.js';
+
+function filterTargets(config: PipelineConfig, options: PipelineRunOptions): PipelineConfig['targets'] {
+  if (!options.targets || options.targets.length === 0) {
+    return config.targets;
+  }
+  const wanted = new Set(options.targets);
+  return config.targets.filter((target) => wanted.has(target.slug));
+}
+
+function mergeRecord(base: PipelineRecord | undefined, next: PipelineRecord): PipelineRecord {
+  if (!base) return next;
+  return {
+    ...base,
+    ...next,
+    categories: next.categories ?? base.categories,
+    tags: next.tags ?? base.tags,
+    aiTags: next.aiTags ?? base.aiTags,
+    aiCategories: next.aiCategories ?? base.aiCategories,
+    aiColors: next.aiColors ?? base.aiColors,
+    aiCaption: next.aiCaption ?? base.aiCaption,
+    remoteUrl: next.remoteUrl ?? base.remoteUrl,
+    compressedPath: next.compressedPath ?? base.compressedPath,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export async function runPipeline(config: PipelineConfig, options: PipelineRunOptions = {}): Promise<PipelineRecord[]> {
+  const targets = filterTargets(config, options);
+  const csvRecords = await loadCsv(config.csvPath);
+  const recordMap = new Map<string, PipelineRecord>();
+  for (const record of csvRecords) {
+    recordMap.set(record.id, record);
+  }
+
+  const aiAnalyzer = !options.skipAi && config.ai?.enabled
+    ? new AiAnalyzer({
+        outputDir: config.compression.outputDir,
+        maxWidth: config.compression.maxWidth,
+        quality: config.compression.quality,
+        classifierModel: config.ai.classifierModel,
+        captionModel: config.ai.captionModel,
+        maxTags: config.ai.maxTags,
+      })
+    : undefined;
+
+  for (const target of targets) {
+    if (options.skipScrape) continue;
+    console.log(`[pipeline] Scraping target ${target.name}`);
+    const scraped = await scrapeTarget(target);
+    console.log(`[pipeline] Found ${scraped.length} assets for ${target.name}`);
+    const downloaded = await downloadImages(scraped, { baseDir: config.outputDir });
+    console.log(`[pipeline] Downloaded ${downloaded.length} assets for ${target.name}`);
+
+    for (const item of downloaded) {
+      const base = recordMap.get(item.id);
+      let record = mergeRecord(base, {
+        ...item,
+        updatedAt: new Date().toISOString(),
+      });
+
+      const shouldAnalyze = aiAnalyzer && (!base || !base.aiTags || base.aiTags.length === 0);
+      if (shouldAnalyze) {
+        try {
+          const analysis = await aiAnalyzer!.analyze(item);
+          record = mergeRecord(record, {
+            ...record,
+            compressedPath: analysis.compressedPath ?? record.compressedPath,
+            aiTags: analysis.tags ?? record.aiTags,
+            aiCategories: analysis.categories ?? record.aiCategories,
+            aiColors: analysis.dominantColors ?? record.aiColors,
+            aiCaption: analysis.caption ?? record.aiCaption,
+            updatedAt: new Date().toISOString(),
+          });
+        } catch (error) {
+          console.warn('[pipeline] AI analysis failed for', item.id, error);
+        }
+      }
+
+      recordMap.set(record.id, record);
+    }
+  }
+
+  let mergedRecords = Array.from(recordMap.values());
+
+  if (config.cos?.enabled && !options.skipUpload) {
+    console.log('[pipeline] Uploading assets to Tencent COS');
+    const pending = mergedRecords.filter((record) => !record.remoteUrl);
+    if (pending.length > 0) {
+      const uploaded = await uploadToCos(pending, config.cos);
+      const uploadedMap = new Map(uploaded.map((item) => [item.id, item] as const));
+      mergedRecords = mergedRecords.map((record) => uploadedMap.get(record.id) ?? record);
+    }
+  }
+
+  await saveCsv(config.csvPath, mergedRecords);
+  console.log(`[pipeline] CSV saved to ${config.csvPath}`);
+  return mergedRecords;
+}

--- a/src/pipeline/run.ts
+++ b/src/pipeline/run.ts
@@ -1,0 +1,44 @@
+import { Command } from 'commander';
+import { loadConfig } from './config.js';
+import { runPipeline } from './pipeline.js';
+import { PipelineRunOptions } from './types.js';
+
+const program = new Command();
+
+program
+  .name('demon-slayer-pipeline')
+  .description('Scrape wallpapers, enrich metadata and manage uploads.');
+
+program
+  .command('run')
+  .description('Run the scraping, AI analysis and upload pipeline')
+  .option('-c, --config <path>', 'Path to pipeline config', 'pipeline.config.json')
+  .option('-t, --targets <list>', 'Comma separated target slugs')
+  .option('--skip-ai', 'Skip AI analysis step')
+  .option('--skip-upload', 'Skip Tencent COS upload step')
+  .option('--skip-scrape', 'Skip scraping and downloading (useful for re-running AI/upload)')
+  .action(async (options) => {
+    const config = await loadConfig(options.config);
+    const runOptions: PipelineRunOptions = {
+      targets: options.targets ? String(options.targets).split(',').map((item) => item.trim()).filter(Boolean) : undefined,
+      skipAi: options.skipAi ?? false,
+      skipUpload: options.skipUpload ?? false,
+      skipScrape: options.skipScrape ?? false,
+    };
+
+    await runPipeline(config, runOptions);
+  });
+
+program
+  .command('upload')
+  .description('Upload existing items to Tencent COS and update the CSV')
+  .option('-c, --config <path>', 'Path to pipeline config', 'pipeline.config.json')
+  .action(async (options) => {
+    const config = await loadConfig(options.config);
+    await runPipeline(config, { skipScrape: true, skipAi: true, skipUpload: false });
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/pipeline/scrape.ts
+++ b/src/pipeline/scrape.ts
@@ -1,0 +1,135 @@
+import { load } from 'cheerio';
+import type { CheerioAPI, Element } from 'cheerio';
+import { ScrapeTarget, ScrapedImage } from './types.js';
+import { createDeterministicId, ensureAbsolute } from './utils.js';
+
+async function fetchPage(url: string, headers?: Record<string, string>): Promise<string> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'demon-slayer-pipeline/1.0 (+https://github.com/)',
+      Accept: 'text/html,application/xhtml+xml',
+      ...headers,
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return await response.text();
+}
+
+function extractField($: CheerioAPI, element: Element, field?: ScrapeTarget['title']): string | undefined {
+  if (!field) return undefined;
+  const node = $(element).find(field.selector).first();
+  if (!node || node.length === 0) {
+    if (field.required) {
+      throw new Error(`Missing required selector ${field.selector}`);
+    }
+    return undefined;
+  }
+  let value: string | undefined;
+  if (field.type === 'attr' && field.attr) {
+    value = node.attr(field.attr) ?? undefined;
+  } else if (field.attr) {
+    value = node.attr(field.attr) ?? undefined;
+  } else {
+    value = node.text();
+  }
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed;
+}
+
+function resolveValues(value?: string, splitter?: string): string[] | undefined {
+  if (!value) return undefined;
+  if (!splitter) return [value];
+  return value
+    .split(splitter)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function deriveImageUrl(
+  $: CheerioAPI,
+  element: Element,
+  target: ScrapeTarget,
+): string | undefined {
+  const selector = target.image.selector ?? 'img';
+  const node = $(element).find(selector).first();
+  if (!node || node.length === 0) return undefined;
+  let src: string | undefined;
+  if (target.image.dataAttr) {
+    src = node.data(target.image.dataAttr) as string | undefined;
+  }
+  if (!src && target.image.attr) {
+    src = node.attr(target.image.attr) ?? undefined;
+  }
+  if (!src) {
+    src = node.attr('src') ?? node.attr('data-src') ?? undefined;
+  }
+  if (!src) return undefined;
+  const base = target.baseUrl ?? target.url;
+  return ensureAbsolute(base, src);
+}
+
+export async function scrapeTarget(target: ScrapeTarget): Promise<ScrapedImage[]> {
+  const pages: string[] = [];
+  if (target.pagination) {
+    const step = target.pagination.step ?? 1;
+    const param = target.pagination.param ?? 'page';
+    if (target.pagination.type === 'pageParam') {
+      for (let page = target.pagination.start; page <= target.pagination.end; page += step) {
+        const url = new URL(target.url);
+        url.searchParams.set(param, String(page));
+        pages.push(url.toString());
+      }
+    } else {
+      const base = target.url.endsWith('/') ? target.url : `${target.url}/`;
+      for (let page = target.pagination.start; page <= target.pagination.end; page += step) {
+        const url = new URL(String(page), base).toString();
+        pages.push(url);
+      }
+    }
+  } else {
+    pages.push(target.url);
+  }
+
+  const results: ScrapedImage[] = [];
+  for (const pageUrl of pages) {
+    const html = await fetchPage(pageUrl, target.requestHeaders);
+    const $ = load(html);
+    const items = $(target.itemSelector);
+
+    items.each((_, element) => {
+      const imageUrl = deriveImageUrl($, element, target);
+      if (!imageUrl) return;
+      const titleRaw = extractField($, element, target.title);
+      const descriptionRaw = extractField($, element, target.description);
+
+      const categoriesValue = typeof target.category === 'string'
+        ? target.category
+        : extractField($, element, target.category);
+      const tagsValue = extractField($, element, target.tags);
+
+      const categories = resolveValues(categoriesValue, target.category && typeof target.category !== 'string' ? target.category.split : undefined);
+      const tags = resolveValues(tagsValue, target.tags?.split);
+      const id = `${target.slug}-${createDeterministicId(pageUrl, imageUrl)}`;
+      const record: ScrapedImage = {
+        id,
+        target,
+        pageUrl,
+        imageUrl,
+        title: titleRaw?.trim(),
+        description: descriptionRaw?.trim(),
+        categories,
+        tags,
+      };
+      results.push(record);
+    });
+  }
+
+  const deduped = new Map<string, ScrapedImage>();
+  for (const item of results) {
+    deduped.set(item.id, item);
+  }
+  return Array.from(deduped.values());
+}

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,0 +1,109 @@
+import type { Stats } from 'sharp';
+
+export interface FieldSelector {
+  selector: string;
+  attr?: string;
+  type?: 'text' | 'attr';
+  split?: string;
+  required?: boolean;
+}
+
+export interface ScrapeTarget {
+  name: string;
+  slug: string;
+  url: string;
+  baseUrl?: string;
+  itemSelector: string;
+  image: {
+    selector?: string;
+    attr?: string;
+    dataAttr?: string;
+  };
+  title?: FieldSelector;
+  description?: FieldSelector;
+  category?: FieldSelector | string;
+  tags?: FieldSelector;
+  pagination?: {
+    type: 'pageParam' | 'increment';
+    start: number;
+    end: number;
+    param?: string;
+    step?: number;
+  };
+  requestHeaders?: Record<string, string>;
+}
+
+export interface PipelineConfig {
+  outputDir: string;
+  csvPath: string;
+  compression: {
+    outputDir: string;
+    maxWidth: number;
+    quality: number;
+  };
+  ai?: {
+    enabled: boolean;
+    classifierModel?: string;
+    captionModel?: string;
+    maxTags?: number;
+  };
+  cos?: {
+    enabled: boolean;
+    bucket: string;
+    region: string;
+    folder?: string;
+    forcePathStyle?: boolean;
+  };
+  targets: ScrapeTarget[];
+}
+
+export interface ScrapedImage {
+  id: string;
+  target: ScrapeTarget;
+  pageUrl: string;
+  imageUrl: string;
+  title?: string;
+  description?: string;
+  categories?: string[];
+  tags?: string[];
+}
+
+export interface DownloadedImage extends ScrapedImage {
+  fileName: string;
+  localPath: string;
+  sha256: string;
+  bytes: number;
+  ext: string;
+}
+
+export interface AiAnalysis {
+  compressedPath?: string;
+  tags?: string[];
+  categories?: string[];
+  dominantColors?: string[];
+  caption?: string;
+}
+
+export interface PipelineRecord extends DownloadedImage {
+  compressedPath?: string;
+  remoteUrl?: string;
+  aiTags?: string[];
+  aiCategories?: string[];
+  aiColors?: string[];
+  aiCaption?: string;
+  updatedAt: string;
+}
+
+export interface PipelineRunOptions {
+  targets?: string[];
+  skipAi?: boolean;
+  skipUpload?: boolean;
+  skipScrape?: boolean;
+}
+
+export interface ScrapeContext {
+  html: string;
+  requestUrl: string;
+}
+
+export type ColorStats = Stats['dominant'];

--- a/src/pipeline/utils.ts
+++ b/src/pipeline/utils.ts
@@ -1,0 +1,66 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import fsExtra from 'fs-extra';
+import slugify from 'slugify';
+
+export function createDeterministicId(...parts: string[]): string {
+  const hash = crypto.createHash('sha1');
+  for (const part of parts) {
+    hash.update(part);
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+export function sanitizeFileName(input: string): string {
+  const base = slugify(input, { lower: true, strict: true });
+  return base.length > 0 ? base : crypto.randomUUID();
+}
+
+export async function ensureDir(dirPath: string): Promise<void> {
+  await fsExtra.ensureDir(dirPath);
+}
+
+export function ensureAbsolute(base: string, maybeRelative: string): string {
+  try {
+    return new URL(maybeRelative, base).toString();
+  } catch (error) {
+    return maybeRelative;
+  }
+}
+
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function fileNameWithExt(name: string, ext: string): string {
+  const clean = sanitizeFileName(name);
+  return `${clean}.${ext.replace(/^\./, '')}`;
+}
+
+export function guessExtensionFromUrl(url: string): string {
+  const pathname = new URL(url).pathname;
+  const ext = path.extname(pathname);
+  if (ext) {
+    return ext.replace('.', '');
+  }
+  return 'jpg';
+}
+
+export function decodeCsvArray(value?: string): string[] | undefined {
+  if (!value) return undefined;
+  return value
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function encodeCsvArray(values?: string[]): string | undefined {
+  if (!values || values.length === 0) return undefined;
+  return values.join(' | ');
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,99 @@
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { loadConfig } from '../pipeline/config.js';
+import { runPipeline } from '../pipeline/pipeline.js';
+import { loadCsv } from '../pipeline/csv.js';
+import type { PipelineRecord } from '../pipeline/types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const app = express();
+const port = Number(process.env.PORT || 3000);
+const configPath = process.env.PIPELINE_CONFIG || 'pipeline.config.json';
+
+app.set('views', path.join(__dirname, 'views'));
+app.set('view engine', 'ejs');
+app.use(express.urlencoded({ extended: true }));
+app.use('/public', express.static(path.join(__dirname, 'public')));
+
+function buildStats(records: PipelineRecord[]) {
+  const total = records.length;
+  const pendingUpload = records.filter((record) => !record.remoteUrl).length;
+  const withAi = records.filter((record) => record.aiTags && record.aiTags.length > 0).length;
+  return { total, pendingUpload, withAi };
+}
+
+app.get('/', async (req, res, next) => {
+  try {
+    const config = await loadConfig(configPath);
+    const records = await loadCsv(config.csvPath);
+    const targetNames = new Map(config.targets.map((target) => [target.slug, target.name] as const));
+    const sorted = records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, 25);
+    const message = req.query.message as string | undefined;
+
+    res.render('index', {
+      config,
+      stats: buildStats(records),
+      records: sorted,
+      targetNames,
+      message,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get('/preview', (req, res) => {
+  const filePath = req.query.path;
+  if (!filePath || typeof filePath !== 'string') {
+    res.status(400).send('Missing path');
+    return;
+  }
+  const resolved = path.resolve(filePath);
+  const root = path.resolve('.');
+  if (!resolved.startsWith(root)) {
+    res.status(403).send('Forbidden');
+    return;
+  }
+  res.sendFile(resolved);
+});
+
+app.post('/run', async (req, res, next) => {
+  try {
+    const config = await loadConfig(configPath);
+    const targets = Array.isArray(req.body.targets)
+      ? req.body.targets
+      : req.body.targets
+        ? [req.body.targets]
+        : undefined;
+    await runPipeline(config, {
+      targets,
+      skipAi: Boolean(req.body.skipAi),
+      skipUpload: Boolean(req.body.skipUpload),
+    });
+    res.redirect('/?message=Pipeline%20completed');
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.post('/upload', async (req, res, next) => {
+  try {
+    const config = await loadConfig(configPath);
+    await runPipeline(config, { skipScrape: true, skipAi: true, skipUpload: false });
+    res.redirect('/?message=Upload%20completed');
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+  console.error(err);
+  res.status(500).send(err.message);
+});
+
+app.listen(port, () => {
+  console.log(`Pipeline dashboard running at http://localhost:${port}`);
+});

--- a/src/server/public/styles.css
+++ b/src/server/public/styles.css
@@ -1,0 +1,165 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.95));
+}
+
+h1, h2 {
+  margin: 0 0 1rem 0;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+header .message {
+  background: #22c55e;
+  color: #022c22;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: bold;
+}
+
+.actions {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(8px);
+}
+
+.card button {
+  margin-top: 1rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  color: white;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.3);
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stats ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 2rem;
+}
+
+.stats li {
+  background: rgba(30, 41, 59, 0.8);
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead {
+  background: rgba(30, 41, 59, 0.8);
+}
+
+td, th {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  vertical-align: top;
+}
+
+tbody tr:hover {
+  background: rgba(79, 70, 229, 0.1);
+}
+
+.tag-list {
+  display: inline-block;
+}
+
+.color-swatches {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.swatch {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: var(--color, #94a3b8);
+}
+
+td img {
+  width: 100px;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.empty {
+  text-align: center;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .stats ul {
+    flex-direction: column;
+  }
+}

--- a/src/server/views/index.ejs
+++ b/src/server/views/index.ejs
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>采集管道仪表盘</title>
+    <link rel="stylesheet" href="/public/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>采集与处理管道</h1>
+      <% if (message) { %>
+        <p class="message"><%= message %></p>
+      <% } %>
+    </header>
+
+    <section class="actions">
+      <div class="card">
+        <h2>运行采集</h2>
+        <form method="post" action="/run">
+          <fieldset>
+            <legend>选择站点</legend>
+            <% config.targets.forEach((target) => { %>
+              <label class="checkbox">
+                <input type="checkbox" name="targets" value="<%= target.slug %>" />
+                <span><%= target.name %> (<%= target.slug %>)</span>
+              </label>
+            <% }) %>
+          </fieldset>
+          <div class="options">
+            <label>
+              <input type="checkbox" name="skipAi" />
+              跳过本地 AI 识别
+            </label>
+            <label>
+              <input type="checkbox" name="skipUpload" />
+              跳过 COS 上传
+            </label>
+          </div>
+          <button type="submit">开始运行</button>
+        </form>
+      </div>
+      <div class="card">
+        <h2>仅上传到 COS</h2>
+        <form method="post" action="/upload">
+          <p>跳过采集与 AI，上传所有未上传的图片到腾讯云 COS。</p>
+          <button type="submit">执行上传</button>
+        </form>
+      </div>
+    </section>
+
+    <section class="stats">
+      <h2>数据概览</h2>
+      <ul>
+        <li>记录总数：<strong><%= stats.total %></strong></li>
+        <li>待上传：<strong><%= stats.pendingUpload %></strong></li>
+        <li>已完成 AI 标签：<strong><%= stats.withAi %></strong></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>最新处理记录</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>来源</th>
+              <th>标题</th>
+              <th>标签</th>
+              <th>颜色</th>
+              <th>描述</th>
+              <th>预览</th>
+              <th>上传状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if (records.length === 0) { %>
+              <tr>
+                <td colspan="8" class="empty">暂无数据</td>
+              </tr>
+            <% } %>
+            <% records.forEach((record) => { %>
+              <tr>
+                <td><code><%= record.id %></code></td>
+                <td><%= targetNames.get(record.target.slug) || record.target.slug %></td>
+                <td><%= record.title || '-' %></td>
+                <td>
+                  <% if (record.aiTags && record.aiTags.length > 0) { %>
+                    <span class="tag-list"><%= record.aiTags.join(', ') %></span>
+                  <% } else if (record.tags && record.tags.length > 0) { %>
+                    <span class="tag-list"><%= record.tags.join(', ') %></span>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td>
+                  <% if (record.aiColors && record.aiColors.length > 0) { %>
+                    <div class="color-swatches">
+                      <% record.aiColors.forEach((color) => { %>
+                        <span class="swatch" style="--color:<%= color %>" title="<%= color %>"></span>
+                      <% }) %>
+                    </div>
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td><%= record.aiCaption || record.description || '-' %></td>
+                <td>
+                  <% if (record.compressedPath || record.localPath) { %>
+                    <img src="/preview?path=<%= encodeURIComponent(record.compressedPath || record.localPath) %>" alt="预览" />
+                  <% } else { %>
+                    -
+                  <% } %>
+                </td>
+                <td>
+                  <% if (record.remoteUrl) { %>
+                    <a href="<%= record.remoteUrl %>" target="_blank" rel="noopener">已上传</a>
+                  <% } else { %>
+                    待上传
+                  <% } %>
+                </td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a configurable scraping pipeline that normalizes metadata, writes CSV output, and can run optional AI annotation and COS uploads
- ship command line entry points plus an Express-based dashboard for managing scrape runs, reviewing records, and triggering uploads
- document the new workflow and provide a sample pipeline configuration for quick setup

## Testing
- Unable to run `bun install` (registry returned HTTP 403)

------
https://chatgpt.com/codex/tasks/task_e_68d8b51c7ad4832985a2af07af53ebd6